### PR TITLE
Add support for ResiliencePipeline(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ x64/
 x86/
 [Bb]in/
 [Oo]bj/
+nugets/
 
 # Visual Studio cache/options directory
 .vs/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NServiceBus.Extensions.DispatchRetries
 
-NServiceBus.Extensions.DispatchRetries is designed to allow to plug in [Polly](https://github.com/App-vNext/Polly) into the outgoing pipeline to retry message dispatching using Polly async policies.
+NServiceBus.Extensions.DispatchRetries is designed to allow to plug in [Polly](https://github.com/App-vNext/Polly) into the outgoing pipeline to retry message dispatching using Polly async policies or resilient strategies.
 
 ## Unreliable environments
 
@@ -30,7 +30,7 @@ class MyController
 
 In unreliable environments, if the above send operation fails, an exception will be thrown and will eventually result in a HTTP500 returned to the caller. Most of the time, retrying is a good enough countermeasure that will succeed.
 
-NServiceBus.Extensions.DispatchRetries can be configured to introduce a Polly async policy into the NServiceBus outgoing pipeline to atomatically retry dispatch operations:
+NServiceBus.Extensions.DispatchRetries can be configured to introduce a Polly async policy into the NServiceBus outgoing pipeline to automatically retry dispatch operations:
 
 ```csharp
 var endpointConfiguration = new EndpointConfiguration("myEndpointName");
@@ -39,6 +39,22 @@ var endpointConfiguration = new EndpointConfiguration("myEndpointName");
 var retryPolicy = Policy.Handle<Exception>().RetryAsync(3);
 //enable DispatchRetries Feature
 endpointConfiguration.DispatchRetries(retryPolicy);
+```
+
+or a resilence strategy:
+
+```csharp
+var endpointConfiguration = new EndpointConfiguration("myEndpointName");
+
+//define a Polly resilience pipeline
+var resiliencePipeline = new ResiliencePipelineBuilder()
+    .AddRetry(new RetryStrategyOptions 
+    {
+        MaxRetryAttempts = 3,
+        OnRetry = _ => ValueTask.CompletedTask
+    })
+//enable DispatchRetries Feature
+endpointConfiguration.DispatchRetries(resiliencePipeline);
 ```
 
 With the above configuration in place, all _immediate_ and _batch_ dispatch operations will be retried 3 times in case of dispatch failures.
@@ -101,7 +117,7 @@ In this last case, both `AMessage` and `AnotherMessage` are always dispatched im
 
 ## Usage
 
-Basic configuration:
+Basic configuration using policies:
 
 ```csharp
 var endpointConfiguration = new EndpointConfiguration("myEndpointName");
@@ -112,9 +128,28 @@ var retryPolicy = Policy.Handle<Exception>().RetryAsync(3);
 endpointConfiguration.DispatchRetries(retryPolicy);
 ```
 
+Basic configuration using a resilience strategy:
+
+```csharp
+var endpointConfiguration = new EndpointConfiguration("myEndpointName");
+
+//define a Polly resilience pipeline
+var resiliencePipeline = new ResiliencePipelineBuilder()
+    .AddRetry(new RetryStrategyOptions 
+    {
+        MaxRetryAttempts = 3,
+        OnRetry = _ => ValueTask.CompletedTask
+    })
+//enable DispatchRetries Feature
+endpointConfiguration.DispatchRetries(resiliencePipeline);
+```
+
 With the above configuration in place, all dispatch operations that fail will be retried 3 times before failing.
 
-It's possible to configure different policies for immediate or batch operations using the following code:
+> [!NOTE]
+> In case both a policy and a resilience strategy are defined, the resilience strategy will be used.
+
+It's possible to configure different policies or resilience strategies for immediate or batch operations. The following example shows how to define different policies for immediate and batch operations:
 
 ```csharp
 var endpointConfiguration = new EndpointConfiguration("myEndpointName");
@@ -133,13 +168,15 @@ var batchRetryPolicy = Policy.Handle<Exception>().RetryAsync(3);
 dispatchRetriesConfig.DefaultImmediateDispatchRetriesPolicy(batchRetryPolicy);
 ```
 
+To define different resilience strategies use `DefaultImmediateDispatchRetriesResilienceStrategy` and `DefaultBatchDispatchRetriesResilienceStrategy`.
+
 ### A note on retrying batch operations
 
 It's important to keep in mind the impact that retrying batch operations can have. When handling an incoming message there is an implicit timeout surrounding the message processing. This timeout can be enforced by the underlying infrastructure or by surrounding transactions. In this context, retrying a batch dispatch counts towards reaching any infrastructure or transaction timeout. Unless it is strictly necessary, it's better to let the [NServiceBus recoverability](https://docs.particular.net/nservicebus/recoverability/) mechanism to handle the failure. There are cases, though, in which retrying an incoming message to handle a dispatch failure might not be desirable, and it might be better to retry a few times the dispatch operation before reverting to the built-in recoverability mechanism. In essence: handle with care.
 
 ### Overrides
 
-When in the context of an incoming message, it might happen that the default configured retry policy doesn't satisfy the requirements. It's possible to override the default configured policy at the message handling context level:
+When in the context of an incoming message, it might happen that the default configured retry policy doesn't satisfy the requirements. It's possible to override the default configured policy or resilience strategy at the message handling context level:
 
 ```csharp
 class MyMessageHandler : IHandleMessages<MyMessage>
@@ -156,15 +193,15 @@ class MyMessageHandler : IHandleMessages<MyMessage>
 }
 ```
 
-`OverrideBatchDispatchRetryPolicy` can be used in a similar fashion to override the default batch dispatch retries policy.
+`OverrideBatchDispatchRetryPolicy` can be used in a similar fashion to override the default batch dispatch retries policy. To override resilience strategies use `OverrideImmediateDispatchRetryResilienceStrategy` and `OverrideBatchDispatchRetryResilienceStrategy`.
 
 #### A note on the NServiceBus Outbox
 
-NServiceBus.Extensions.DispatchRetries works with the [NServiceBus Outbox](https://docs.particular.net/nservicebus/outbox/) as well. Due to the way the outbox is implemented the policy applied to outgoing messages is always the immediate dispatch policy when using the outbox.
+NServiceBus.Extensions.DispatchRetries works with the [NServiceBus Outbox](https://docs.particular.net/nservicebus/outbox/) as well. Due to the way the outbox is implemented the policy or resilience strategy applied to outgoing messages is always the immediate dispatch one when using the outbox.
 
 #### A note on dispatching messages outside the context of an incoming message
 
-When dispatching messages, using either `IMessageSession` or `IEndpointInstance`, messages are immediately dispatched to the underlying transport without any batching. Due to the way NServiceBus works in this case the policy applied to outgoing messages is always the batch dispatch policy. 
+When dispatching messages, using either `IMessageSession` or `IEndpointInstance`, messages are immediately dispatched to the underlying transport without any batching. Due to the way NServiceBus works in this case the policy applied to outgoing messages is always the batch dispatch policy.
 
 ## How to install
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ var resiliencePipeline = new ResiliencePipelineBuilder()
         MaxRetryAttempts = 3,
         OnRetry = _ => ValueTask.CompletedTask
     })
+    .Build();
 //enable DispatchRetries Feature
 endpointConfiguration.DispatchRetries(resiliencePipeline);
 ```
@@ -140,6 +141,7 @@ var resiliencePipeline = new ResiliencePipelineBuilder()
         MaxRetryAttempts = 3,
         OnRetry = _ => ValueTask.CompletedTask
     })
+    .Build();
 //enable DispatchRetries Feature
 endpointConfiguration.DispatchRetries(resiliencePipeline);
 ```

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/NServiceBus.Extensions.DispatchRetries.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/NServiceBus.Extensions.DispatchRetries.AcceptanceTests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="6.0.0" />
+    <PackageReference Include="ApprovalUtilities" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Npgsql" Version="8.0.5" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.2" />

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/NServiceBus.Extensions.DispatchRetries.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/NServiceBus.Extensions.DispatchRetries.AcceptanceTests.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.2.2" />
+    <PackageReference Include="Polly" Version="8.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Extensions.DispatchRetries\NServiceBus.Extensions.DispatchRetries.csproj" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/NServiceBus.Extensions.DispatchRetries.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/NServiceBus.Extensions.DispatchRetries.AcceptanceTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Npgsql" Version="8.0.4" />
+    <PackageReference Include="Npgsql" Version="8.0.5" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.2" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="8.1.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
@@ -29,7 +29,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.MessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetriesWithPolicy));
+            Assert.That(_numberOfPollyRetriesWithPolicy, Is.EqualTo(1));
         }
         
         [Test]
@@ -48,7 +48,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.MessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetriesWithResilienceStrategy));
+            Assert.That(_numberOfPollyRetriesWithResilienceStrategy, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
@@ -4,18 +4,20 @@ using NServiceBus.AcceptanceTesting;
 using NServiceBus.AttributeRouting.AcceptanceTests;
 using NUnit.Framework;
 using Polly;
+using Polly.Retry;
 
 namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 {
     public class When_sending_from_message_session
     {
-        private static int _numberOfPollyRetries = 0;
+        private static int _numberOfPollyRetriesWithPolicy = 0;
+        private static int _numberOfPollyRetriesWithResielnceStrategy = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<SenderEndpoint>(g => g.When(b =>
+                .WithEndpoint<SenderEndpointWithPolicy>(g => g.When(b =>
                 {
                     var options = new SendOptions();
                     options.SetDestination("ReceiverEndpoint");
@@ -27,7 +29,26 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.MessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetries));
+            Assert.That(1, Is.EqualTo(_numberOfPollyRetriesWithPolicy));
+        }
+        
+        [Test]
+        public async Task should_be_retried_according_to_resilience_pipeline()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpointWithResiliencePipeline>(g => g.When(b =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination("ReceiverEndpoint");
+
+                    return b.Send(new Message(), options);
+                }))
+                .WithEndpoint<ReceiverEndpoint>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.That(context.MessageReceived, Is.True);
+            Assert.That(1, Is.EqualTo(_numberOfPollyRetriesWithResielnceStrategy));
         }
 
         class Context : ScenarioContext
@@ -35,9 +56,9 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             public bool MessageReceived { get; set; }
         }
 
-        class SenderEndpoint : EndpointConfigurationBuilder
+        class SenderEndpointWithPolicy : EndpointConfigurationBuilder
         {
-            public SenderEndpoint()
+            public SenderEndpointWithPolicy()
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
@@ -45,10 +66,34 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfPollyRetries++;
+                            _numberOfPollyRetriesWithPolicy++;
                         });
 
-                    var dispatchRetriesOptions= config.DispatchRetries(policy);
+                    _ = config.DispatchRetries(policy);
+                });
+            }
+        }
+        
+        class SenderEndpointWithResiliencePipeline : EndpointConfigurationBuilder
+        {
+            public SenderEndpointWithResiliencePipeline()
+            {
+                EndpointSetup<UnreliableServer>(config =>
+                {
+                    var o = new RetryStrategyOptions 
+                    {
+                        MaxRetryAttempts = 1,
+                        OnRetry = _ =>
+                        {
+                            _numberOfPollyRetriesWithResielnceStrategy++;
+                            return ValueTask.CompletedTask;
+                        }
+                    };
+
+                    var pipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(o)
+                        .Build();
+                    _ = config.DispatchRetries(pipeline);
                 });
             }
         }

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpointWithPolicy>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))
@@ -39,7 +39,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpointWithResiliencePipeline>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
@@ -80,18 +80,16 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
-                    var o = new RetryStrategyOptions 
-                    {
-                        MaxRetryAttempts = 1,
-                        OnRetry = _ =>
-                        {
-                            _numberOfPollyRetriesWithResilienceStrategy++;
-                            return ValueTask.CompletedTask;
-                        }
-                    };
-
                     var pipeline = new ResiliencePipelineBuilder()
-                        .AddRetry(o)
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfPollyRetriesWithResilienceStrategy++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
                         .Build();
                     _ = config.DispatchRetries(pipeline);
                 });

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_from_message_session.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
     public class When_sending_from_message_session
     {
         private static int _numberOfPollyRetriesWithPolicy = 0;
-        private static int _numberOfPollyRetriesWithResielnceStrategy = 0;
+        private static int _numberOfPollyRetriesWithResilienceStrategy = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
@@ -48,7 +48,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.MessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetriesWithResielnceStrategy));
+            Assert.That(1, Is.EqualTo(_numberOfPollyRetriesWithResilienceStrategy));
         }
 
         class Context : ScenarioContext
@@ -85,7 +85,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         MaxRetryAttempts = 1,
                         OnRetry = _ =>
                         {
-                            _numberOfPollyRetriesWithResielnceStrategy++;
+                            _numberOfPollyRetriesWithResilienceStrategy++;
                             return ValueTask.CompletedTask;
                         }
                     };

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler.cs
@@ -33,8 +33,8 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 
             Assert.That(context.ReplyMessageReceived, Is.True);
             Assert.That(context.AnotherReplyMessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfImmediatePollyPolicyRetries), "Wrong number of immediate policy retries");
-            Assert.That(1, Is.EqualTo(_numberOfBatchPollyPolicyRetries), "Wrong number of batch policy retries");
+            Assert.That(_numberOfImmediatePollyPolicyRetries, Is.EqualTo(1), "Wrong number of immediate policy retries");
+            Assert.That(_numberOfBatchPollyPolicyRetries, Is.EqualTo(1), "Wrong number of batch policy retries");
         }
         
         [Test]
@@ -54,8 +54,8 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 
             Assert.That(context.ReplyMessageReceived, Is.True);
             Assert.That(context.AnotherReplyMessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfImmediatePollyResiliencePipelineRetries), "Wrong number of immediate resilience pipeline retries");
-            Assert.That(1, Is.EqualTo(_numberOfBatchPollyResiliencePipelineRetries), "Wrong number of batch resilience pipeline retries");
+            Assert.That(_numberOfImmediatePollyResiliencePipelineRetries, Is.EqualTo(1), "Wrong number of immediate resilience pipeline retries");
+            Assert.That(_numberOfBatchPollyResiliencePipelineRetries, Is.EqualTo(1), "Wrong number of batch resilience pipeline retries");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler.cs
@@ -179,8 +179,8 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Build();
 
                     var dispatchRetriesOptions = config.DispatchRetries();
-                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(batchPipeline);
-                    dispatchRetriesOptions.DefaultImmediateDispatchRetriesResiliencePipeline(immediatePipeline);
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResilienceStrategy(batchPipeline);
+                    dispatchRetriesOptions.DefaultImmediateDispatchRetriesResilienceStrategy(immediatePipeline);
                 });
             }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler.cs
@@ -4,13 +4,17 @@ using NServiceBus.AcceptanceTesting;
 using NServiceBus.AttributeRouting.AcceptanceTests;
 using NUnit.Framework;
 using Polly;
+using Polly.Retry;
 
 namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 {
     public class When_sending_immediate_and_batched_messages_from_message_handler
     {
-        private static int _numberOfImmediatePollyRetries = 0;
-        private static int _numberOfBatchPollyRetries = 0;
+        private static int _numberOfImmediatePollyPolicyRetries = 0;
+        private static int _numberOfBatchPollyPolicyRetries = 0;
+        
+        private static int _numberOfImmediatePollyResiliencePipelineRetries = 0;
+        private static int _numberOfBatchPollyResiliencePipelineRetries = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
@@ -19,18 +23,39 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpointWithPolicy));
 
                     return b.Send(new Message(), options);
                 }))
-                .WithEndpoint<ReceiverEndpoint>()
+                .WithEndpoint<ReceiverEndpointWithPolicy>()
                 .Done(c => c.ReplyMessageReceived && c.AnotherReplyMessageReceived)
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
             Assert.That(context.AnotherReplyMessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfImmediatePollyRetries), "Wrong number of immediate policy retries");
-            Assert.That(1, Is.EqualTo(_numberOfBatchPollyRetries), "Wrong number of batch policy retries");
+            Assert.That(1, Is.EqualTo(_numberOfImmediatePollyPolicyRetries), "Wrong number of immediate policy retries");
+            Assert.That(1, Is.EqualTo(_numberOfBatchPollyPolicyRetries), "Wrong number of batch policy retries");
+        }
+        
+        [Test]
+        public async Task should_be_retried_according_to_resilience_pipeline()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpoint>(g => g.When(b =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(nameof(ReceiverEndpointWithResiliencePipeline));
+
+                    return b.Send(new Message(), options);
+                }))
+                .WithEndpoint<ReceiverEndpointWithResiliencePipeline>()
+                .Done(c => c.ReplyMessageReceived && c.AnotherReplyMessageReceived)
+                .Run();
+
+            Assert.That(context.ReplyMessageReceived, Is.True);
+            Assert.That(context.AnotherReplyMessageReceived, Is.True);
+            Assert.That(1, Is.EqualTo(_numberOfImmediatePollyResiliencePipelineRetries), "Wrong number of immediate resilience pipeline retries");
+            Assert.That(1, Is.EqualTo(_numberOfBatchPollyResiliencePipelineRetries), "Wrong number of batch resilience pipeline retries");
         }
 
         class Context : ScenarioContext
@@ -84,29 +109,78 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             }
         }
 
-        class ReceiverEndpoint : EndpointConfigurationBuilder
+        class ReceiverEndpointWithPolicy : EndpointConfigurationBuilder
         {
-            public ReceiverEndpoint()
+            public ReceiverEndpointWithPolicy()
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
                     var batchPolicy = Policy
-                        .Handle<Exception>(ex=>true)
+                        .Handle<Exception>(ex => true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfBatchPollyRetries++;
+                            _numberOfBatchPollyPolicyRetries++;
                         });
 
                     var immediatePolicy = Policy
-                        .Handle<Exception>(ex=>true)
+                        .Handle<Exception>(ex => true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfImmediatePollyRetries++;
+                            _numberOfImmediatePollyPolicyRetries++;
                         });
 
                     var dispatchRetriesOptions = config.DispatchRetries();
                     dispatchRetriesOptions.DefaultBatchDispatchRetriesPolicy(batchPolicy);
                     dispatchRetriesOptions.DefaultImmediateDispatchRetriesPolicy(immediatePolicy);
+                });
+            }
+            
+            class Handler : IHandleMessages<Message>
+            {
+                public async Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    var options = new ReplyOptions();
+                    options.RequireImmediateDispatch();
+                    await context.Reply(new ReplyMessage(), options);
+
+                    await context.Reply(new AnotherReplyMessage());
+                }
+            }
+        }
+
+        class ReceiverEndpointWithResiliencePipeline : EndpointConfigurationBuilder
+        {
+            public ReceiverEndpointWithResiliencePipeline()
+            {
+                EndpointSetup<UnreliableServer>(config =>
+                {
+                    var batchPipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfBatchPollyResiliencePipelineRetries++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
+                        .Build();
+                    
+                    var immediatePipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfImmediatePollyResiliencePipelineRetries++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
+                        .Build();
+
+                    var dispatchRetriesOptions = config.DispatchRetries();
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(batchPipeline);
+                    dispatchRetriesOptions.DefaultImmediateDispatchRetriesResiliencePipeline(immediatePipeline);
                 });
             }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies.cs
@@ -9,10 +9,10 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 {
     public class When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies
     {
-        private static int _numberOfImmediatePollyRetries = 0;
-        private static int _numberOfBatchPollyRetries = 0;
-        private static int _numberOfOverriddenImmediatePollyRetries = 0;
-        private static int _numberOfOverriddenBatchPollyRetries = 0;
+        private static int _numberOfImmediatePollyPolicyRetries = 0;
+        private static int _numberOfBatchPollyPolicyRetries = 0;
+        private static int _numberOfOverriddenImmediatePollyPolicyRetries = 0;
+        private static int _numberOfOverriddenBatchPollyPolicyRetries = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
@@ -21,20 +21,20 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination(nameof(ReceiverEndpoint));
+                    options.SetDestination(nameof(ReceiverEndpointWithPolicy));
 
                     return b.Send(new Message(), options);
                 }))
-                .WithEndpoint<ReceiverEndpoint>()
+                .WithEndpoint<ReceiverEndpointWithPolicy>()
                 .Done(c => c.ReplyMessageReceived && c.AnotherReplyMessageReceived)
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
             Assert.That(context.AnotherReplyMessageReceived, Is.True);
-            Assert.That(_numberOfImmediatePollyRetries, Is.EqualTo(0), "Wrong number of immediate policy retries");
-            Assert.That(_numberOfBatchPollyRetries, Is.EqualTo(0), "Wrong number of batch policy retries");
-            Assert.That(_numberOfOverriddenImmediatePollyRetries, Is.EqualTo(1), "Wrong number of overridden immediate policy retries");
-            Assert.That(_numberOfOverriddenBatchPollyRetries, Is.EqualTo(1), "Wrong number of overridden batch policy retries");
+            Assert.That(_numberOfImmediatePollyPolicyRetries, Is.EqualTo(0), "Wrong number of immediate policy retries");
+            Assert.That(_numberOfBatchPollyPolicyRetries, Is.EqualTo(0), "Wrong number of batch policy retries");
+            Assert.That(_numberOfOverriddenImmediatePollyPolicyRetries, Is.EqualTo(1), "Wrong number of overridden immediate policy retries");
+            Assert.That(_numberOfOverriddenBatchPollyPolicyRetries, Is.EqualTo(1), "Wrong number of overridden batch policy retries");
         }
 
         class Context : ScenarioContext
@@ -88,9 +88,9 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             }
         }
 
-        class ReceiverEndpoint : EndpointConfigurationBuilder
+        class ReceiverEndpointWithPolicy : EndpointConfigurationBuilder
         {
-            public ReceiverEndpoint()
+            public ReceiverEndpointWithPolicy()
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
@@ -98,14 +98,14 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfBatchPollyRetries++;
+                            _numberOfBatchPollyPolicyRetries++;
                         });
 
                     var immediatePolicy = Policy
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfImmediatePollyRetries++;
+                            _numberOfImmediatePollyPolicyRetries++;
                         });
 
                     var dispatchRetriesOptions = config.DispatchRetries();
@@ -122,7 +122,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfOverriddenBatchPollyRetries++;
+                            _numberOfOverriddenBatchPollyPolicyRetries++;
                         });
 
                     context.OverrideBatchDispatchRetryPolicy(batchPolicy);
@@ -131,7 +131,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfOverriddenImmediatePollyRetries++;
+                            _numberOfOverriddenImmediatePollyPolicyRetries++;
                         });
 
                     context.OverrideBatchDispatchRetryPolicy(batchPolicy);

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_and_batched_messages_from_message_handler_and_overriding_policies.cs
@@ -31,10 +31,10 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 
             Assert.That(context.ReplyMessageReceived, Is.True);
             Assert.That(context.AnotherReplyMessageReceived, Is.True);
-            Assert.That(0, Is.EqualTo(_numberOfImmediatePollyRetries), "Wrong number of immediate policy retries");
-            Assert.That(0, Is.EqualTo(_numberOfBatchPollyRetries), "Wrong number of batch policy retries");
-            Assert.That(1, Is.EqualTo(_numberOfOverriddenImmediatePollyRetries), "Wrong number of overridden immediate policy retries");
-            Assert.That(1, Is.EqualTo(_numberOfOverriddenBatchPollyRetries), "Wrong number of overridden batch policy retries");
+            Assert.That(_numberOfImmediatePollyRetries, Is.EqualTo(0), "Wrong number of immediate policy retries");
+            Assert.That(_numberOfBatchPollyRetries, Is.EqualTo(0), "Wrong number of batch policy retries");
+            Assert.That(_numberOfOverriddenImmediatePollyRetries, Is.EqualTo(1), "Wrong number of overridden immediate policy retries");
+            Assert.That(_numberOfOverriddenBatchPollyRetries, Is.EqualTo(1), "Wrong number of overridden batch policy retries");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_from_message_session.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
                     options.RequireImmediateDispatch();
 
                     return b.Send(new Message(), options);

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_from_message_session.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_from_message_session.cs
@@ -4,18 +4,20 @@ using NServiceBus.AcceptanceTesting;
 using NServiceBus.AttributeRouting.AcceptanceTests;
 using NUnit.Framework;
 using Polly;
+using Polly.Retry;
 
 namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 {
     public class When_sending_immediate_from_message_session
     {
-        private static int _numberOfPollyRetries = 0;
+        private static int _numberOfPollyPolicyRetries = 0;
+        private static int _numberOfPollyRetriesWithResilienceStrategy = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<SenderEndpoint>(g => g.When(b =>
+                .WithEndpoint<SenderEndpointWithPolicy>(g => g.When(b =>
                 {
                     var options = new SendOptions();
                     options.SetDestination(nameof(ReceiverEndpoint));
@@ -28,7 +30,27 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.MessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetries));
+            Assert.That(_numberOfPollyPolicyRetries, Is.EqualTo(1));
+        }
+        
+        [Test]
+        public async Task should_be_retried_according_to_resilience_pipeline()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpointWithResiliencePipeline>(g => g.When(b =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(nameof(ReceiverEndpoint));
+                    options.RequireImmediateDispatch();
+
+                    return b.Send(new Message(), options);
+                }))
+                .WithEndpoint<ReceiverEndpoint>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.That(context.MessageReceived, Is.True);
+            Assert.That(_numberOfPollyRetriesWithResilienceStrategy, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext
@@ -36,9 +58,9 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             public bool MessageReceived { get; set; }
         }
 
-        class SenderEndpoint : EndpointConfigurationBuilder
+        class SenderEndpointWithPolicy : EndpointConfigurationBuilder
         {
-            public SenderEndpoint()
+            public SenderEndpointWithPolicy()
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
@@ -46,10 +68,32 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfPollyRetries++;
+                            _numberOfPollyPolicyRetries++;
                         });
 
-                    var dispatchRetriesOptions= config.DispatchRetries(policy);
+                    _ = config.DispatchRetries(policy);
+                });
+            }
+        }
+        
+        class SenderEndpointWithResiliencePipeline : EndpointConfigurationBuilder
+        {
+            public SenderEndpointWithResiliencePipeline()
+            {
+                EndpointSetup<UnreliableServer>(config =>
+                {
+                    var pipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfPollyRetriesWithResilienceStrategy++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
+                        .Build();
+                    _ = config.DispatchRetries(pipeline);
                 });
             }
         }

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
@@ -134,7 +134,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                     _ = config.DispatchRetries(pipeline);
 
                     var dispatchRetriesOptions = config.DispatchRetries();
-                    dispatchRetriesOptions.DefaultImmediateDispatchRetriesResiliencePipeline(pipeline);
+                    dispatchRetriesOptions.DefaultImmediateDispatchRetriesResilienceStrategy(pipeline);
                 });
             }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
@@ -48,7 +48,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(_numberOfPollyPolicyRetries, Is.EqualTo(1));
+            Assert.That(_numberOfPollyResiliencePipelineRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetries));
+            Assert.That(_numberOfPollyRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler_and_overriding_policy.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler_and_overriding_policy.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler_and_overriding_policy.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_immediate_messages_from_message_handler_and_overriding_policy.cs
@@ -28,8 +28,8 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(0, Is.EqualTo(_numberOfPollyRetries));
-            Assert.That(1, Is.EqualTo(_numberOfOverriddenPollyRetries));
+            Assert.That(_numberOfPollyRetries, Is.EqualTo(0));
+            Assert.That(_numberOfOverriddenPollyRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetries));
+            Assert.That(_numberOfPollyRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
@@ -4,12 +4,14 @@ using NServiceBus.AcceptanceTesting;
 using NServiceBus.AttributeRouting.AcceptanceTests;
 using NUnit.Framework;
 using Polly;
+using Polly.Retry;
 
 namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 {
     public class When_sending_messages_in_batch_from_message_handler
     {
-        private static int _numberOfPollyRetries = 0;
+        private static int _numberOfPollyPolicyRetries = 0;
+        private static int _numberOfPollyResiliencePipelineRetries = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
@@ -18,16 +20,35 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination(nameof(ReceiverEndpoint));
+                    options.SetDestination(nameof(ReceiverEndpointWithPolicy));
 
                     return b.Send(new Message(), options);
                 }))
-                .WithEndpoint<ReceiverEndpoint>()
+                .WithEndpoint<ReceiverEndpointWithPolicy>()
                 .Done(c => c.ReplyMessageReceived)
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(_numberOfPollyRetries, Is.EqualTo(1));
+            Assert.That(_numberOfPollyPolicyRetries, Is.EqualTo(1));
+        }
+        
+        [Test]
+        public async Task should_be_retried_according_to_resilience_pipeline()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpoint>(g => g.When(b =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(nameof(ReceiverEndpointWithResiliencePipeline));
+
+                    return b.Send(new Message(), options);
+                }))
+                .WithEndpoint<ReceiverEndpointWithResiliencePipeline>()
+                .Done(c => c.ReplyMessageReceived)
+                .Run();
+
+            Assert.That(context.ReplyMessageReceived, Is.True);
+            Assert.That(_numberOfPollyResiliencePipelineRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext
@@ -63,9 +84,9 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             }
         }
 
-        class ReceiverEndpoint : EndpointConfigurationBuilder
+        class ReceiverEndpointWithPolicy : EndpointConfigurationBuilder
         {
-            public ReceiverEndpoint()
+            public ReceiverEndpointWithPolicy()
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
@@ -73,11 +94,43 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>(ex=>true)
                         .RetryAsync(1, (exception, retryAttempt, context) =>
                         {
-                            _numberOfPollyRetries++;
+                            _numberOfPollyPolicyRetries++;
                         });
 
                     var dispatchRetriesOptions = config.DispatchRetries();
                     dispatchRetriesOptions.DefaultBatchDispatchRetriesPolicy(policy);
+                });
+            }
+
+            class Handler : IHandleMessages<Message>
+            {
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new ReplyMessage());
+                }
+            }
+        }
+        
+        class ReceiverEndpointWithResiliencePipeline : EndpointConfigurationBuilder
+        {
+            public ReceiverEndpointWithResiliencePipeline()
+            {
+                EndpointSetup<UnreliableServer>(config =>
+                {
+                    var pipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfPollyResiliencePipelineRetries++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
+                        .Build();
+
+                    var dispatchRetriesOptions = config.DispatchRetries();
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(pipeline);
                 });
             }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler.cs
@@ -130,7 +130,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Build();
 
                     var dispatchRetriesOptions = config.DispatchRetries();
-                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(pipeline);
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResilienceStrategy(pipeline);
                 });
             }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
@@ -75,7 +75,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(1, Is.EqualTo(_numberOfPollyRetries));
+            Assert.That(_numberOfPollyRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
@@ -48,8 +48,6 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 return Task.FromResult(false);
             }
 
-            ;
-
             await DockerCompose.Up(checker);
         }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
@@ -190,7 +190,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Build();
 
                     var dispatchRetriesOptions = config.DispatchRetries();
-                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(pipeline);
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResilienceStrategy(pipeline);
 
                     var persistence = config.UsePersistence<SqlPersistence>();
                     var dialect = persistence.SqlDialect<SqlDialect.PostgreSql>();

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
@@ -66,7 +66,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_Outbox_is_enabled.cs
@@ -7,6 +7,7 @@ using NServiceBus.AcceptanceTests;
 using NServiceBus.AttributeRouting.AcceptanceTests;
 using NUnit.Framework;
 using Polly;
+using Polly.Retry;
 
 namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 {
@@ -57,7 +58,8 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             DockerCompose.Down();
         }
 
-        private static int _numberOfPollyRetries = 0;
+        private static int _numberOfPollyPolicyRetries = 0;
+        private static int _numberOfPollyResiliencePipelineRetries = 0;
 
         [Test]
         public async Task should_be_retried_according_to_policy()
@@ -66,16 +68,35 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination(nameof(ReceiverEndpoint));
+                    options.SetDestination(nameof(ReceiverEndpointWithPolicy));
 
                     return b.Send(new Message(), options);
                 }))
-                .WithEndpoint<ReceiverEndpoint>()
+                .WithEndpoint<ReceiverEndpointWithPolicy>()
                 .Done(c => c.ReplyMessageReceived)
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(_numberOfPollyRetries, Is.EqualTo(1));
+            Assert.That(_numberOfPollyPolicyRetries, Is.EqualTo(1));
+        }
+        
+        [Test]
+        public async Task should_be_retried_according_to_resilience_pipeline()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpoint>(g => g.When(b =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(nameof(ReceiverEndpointWithResiliencePipeline));
+
+                    return b.Send(new Message(), options);
+                }))
+                .WithEndpoint<ReceiverEndpointWithResiliencePipeline>()
+                .Done(c => c.ReplyMessageReceived)
+                .Run();
+
+            Assert.That(context.ReplyMessageReceived, Is.True);
+            Assert.That(_numberOfPollyResiliencePipelineRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext
@@ -110,9 +131,9 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
             }
         }
 
-        class ReceiverEndpoint : EndpointConfigurationBuilder
+        class ReceiverEndpointWithPolicy : EndpointConfigurationBuilder
         {
-            public ReceiverEndpoint()
+            public ReceiverEndpointWithPolicy()
             {
                 EndpointSetup<UnreliableServer>(config =>
                 {
@@ -120,7 +141,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Handle<Exception>()
                         .RetryAsync(1, (exception, retryAttempt) =>
                         {
-                            _numberOfPollyRetries++;
+                            _numberOfPollyPolicyRetries++;
                         });
 
                     var dispatchRetriesOptions = config.DispatchRetries();
@@ -133,6 +154,52 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         var npgsqlParameter = (NpgsqlParameter)parameter;
                         npgsqlParameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
                     });
+                    persistence.TablePrefix("policy");
+                    persistence.ConnectionBuilder(() => new NpgsqlConnection(postgres_connection));
+
+                    config.SetReceiveOnlyTransactionMode();
+                    config.EnableOutbox();
+                });
+            }
+
+            class Handler : IHandleMessages<Message>
+            {
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new ReplyMessage());
+                }
+            }
+        }
+        
+        class ReceiverEndpointWithResiliencePipeline : EndpointConfigurationBuilder
+        {
+            public ReceiverEndpointWithResiliencePipeline()
+            {
+                EndpointSetup<UnreliableServer>(config =>
+                {
+                    var pipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfPollyResiliencePipelineRetries++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
+                        .Build();
+
+                    var dispatchRetriesOptions = config.DispatchRetries();
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(pipeline);
+
+                    var persistence = config.UsePersistence<SqlPersistence>();
+                    var dialect = persistence.SqlDialect<SqlDialect.PostgreSql>();
+                    dialect.JsonBParameterModifier(parameter =>
+                    {
+                        var npgsqlParameter = (NpgsqlParameter)parameter;
+                        npgsqlParameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+                    });
+                    persistence.TablePrefix("pipeline");
                     persistence.ConnectionBuilder(() => new NpgsqlConnection(postgres_connection));
 
                     config.SetReceiveOnlyTransactionMode();

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .WithEndpoint<SenderEndpoint>(g => g.When(b =>
                 {
                     var options = new SendOptions();
-                    options.SetDestination("ReceiverEndpoint");
+                    options.SetDestination(nameof(ReceiverEndpoint));
 
                     return b.Send(new Message(), options);
                 }))

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
@@ -164,7 +164,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         })
                         .Build();
 
-                    context.OverrideBatchDispatchRetryStrategy(pipeline);
+                    context.OverrideBatchDispatchRetryResilienceStrategy(pipeline);
 
                     return context.Reply(new ReplyMessage());
                 }

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
@@ -28,8 +28,8 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                 .Run();
 
             Assert.That(context.ReplyMessageReceived, Is.True);
-            Assert.That(0, Is.EqualTo(_numberOfPollyRetries));
-            Assert.That(1, Is.EqualTo(_numberOfOverriddenPollyRetries));
+            Assert.That(_numberOfPollyRetries, Is.EqualTo(0));
+            Assert.That(_numberOfOverriddenPollyRetries, Is.EqualTo(1));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_sending_messages_in_batch_from_message_handler_and_overriding_policy.cs
@@ -144,7 +144,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
                         .Build();
 
                     var dispatchRetriesOptions = config.DispatchRetries();
-                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResiliencePipeline(pipeline);
+                    dispatchRetriesOptions.DefaultBatchDispatchRetriesResilienceStrategy(pipeline);
                 });
             }
 

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
 
             
             var warning = context.Logs.Single(l=>l.Level== LogLevel.Warn && l.LoggerName.EndsWith(nameof(BatchDispatchRetriesBehavior)));
-            Approvals.Verify(warning);
+            Approvals.Verify(warning.Message);
             
             Assert.That(context.MessageReceived, Is.True);
             Assert.That(_numberOfPollyRetriesWithPolicy, Is.EqualTo(0));

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ApprovalTests;
+using ApprovalTests.Reporters;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AttributeRouting.AcceptanceTests;
+using NServiceBus.Extensions.DispatchRetries.Behaviors;
+using NServiceBus.Logging;
+using NUnit.Framework;
+using Polly;
+using Polly.Retry;
+
+namespace NServiceBus.Extensions.DispatchRetries.AcceptanceTests
+{
+    public class When_using_policies_and_peipelines_pipelines_are_invoked
+    {
+        private static int _numberOfPollyRetriesWithPolicy = 0;
+        private static int _numberOfPollyRetriesWithResilienceStrategy = 0;
+        
+        [Test]
+        [UseReporter(typeof(DiffReporter))]
+        public async Task should_be_retried_according_to_resilience_pipeline_and_log_warning()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpoint>(g => g.When(b =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(nameof(ReceiverEndpoint));
+
+                    return b.Send(new Message(), options);
+                }))
+                .WithEndpoint<ReceiverEndpoint>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            
+            var warning = context.Logs.Single(l=>l.Level== LogLevel.Warn && l.LoggerName.EndsWith(nameof(BatchDispatchRetriesBehavior)));
+            Approvals.Verify(warning);
+            
+            Assert.That(context.MessageReceived, Is.True);
+            Assert.That(_numberOfPollyRetriesWithPolicy, Is.EqualTo(0));
+            Assert.That(_numberOfPollyRetriesWithResilienceStrategy, Is.EqualTo(1));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+        }
+        
+        class SenderEndpoint : EndpointConfigurationBuilder
+        {
+            public SenderEndpoint()
+            {
+                EndpointSetup<UnreliableServer>(config =>
+                {
+                    var policy = Policy
+                        .Handle<Exception>(ex=>true)
+                        .RetryAsync(1, (exception, retryAttempt, context) =>
+                        {
+                            _numberOfPollyRetriesWithPolicy++;
+                        });
+                    
+                    var pipeline = new ResiliencePipelineBuilder()
+                        .AddRetry(new RetryStrategyOptions 
+                        {
+                            MaxRetryAttempts = 1,
+                            OnRetry = _ =>
+                            {
+                                _numberOfPollyRetriesWithResilienceStrategy++;
+                                return ValueTask.CompletedTask;
+                            }
+                        })
+                        .Build();
+                    
+                    var options = config.DispatchRetries();
+                    options.DefaultBatchDispatchRetriesPolicy(policy);
+                    options.DefaultImmediateDispatchRetriesPolicy(policy);
+                    options.DefaultBatchDispatchRetriesResilienceStrategy(pipeline);
+                    options.DefaultImmediateDispatchRetriesResilienceStrategy(pipeline);
+                });
+            }
+        }
+
+        class ReceiverEndpoint : EndpointConfigurationBuilder
+        {
+            public ReceiverEndpoint()
+            {
+                EndpointSetup<DefaultServer>(config => { });
+            }
+
+            class Handler : IHandleMessages<Message>
+            {
+                private readonly Context _testContext;
+
+                public Handler(Context testContext)
+                {
+                    _testContext = testContext;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    _testContext.MessageReceived = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.should_be_retried_according_to_resilience_pipeline_and_log_warning.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.should_be_retried_according_to_resilience_pipeline_and_log_warning.approved.txt
@@ -1,1 +1,1 @@
-﻿NServiceBus.AcceptanceTesting.ScenarioContext+LogItem
+﻿Both a default batch dispatch retry policy and a batch dispatch retry resilience strategy are configured. Only the batch dispatch retry resilience strategy will be used.

--- a/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.should_be_retried_according_to_resilience_pipeline_and_log_warning.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.AcceptanceTests/When_using_policies_and_peipelines_pipelines_are_invoked.should_be_retried_according_to_resilience_pipeline_and_log_warning.approved.txt
@@ -1,0 +1,1 @@
+﻿NServiceBus.AcceptanceTesting.ScenarioContext+LogItem

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -22,7 +22,8 @@ namespace NServiceBus
     public static class MessageHandlerContextExtensions
     {
         public static void OverrideBatchDispatchRetryPolicy(this NServiceBus.IMessageHandlerContext context, Polly.AsyncPolicy batchDispatchRetryPolicy) { }
-        public static void OverrideBatchDispatchRetryStrategy(this NServiceBus.IMessageHandlerContext context, Polly.ResiliencePipeline batchDispatchRetryResiliencePipeline) { }
+        public static void OverrideBatchDispatchRetryResilienceStrategy(this NServiceBus.IMessageHandlerContext context, Polly.ResiliencePipeline batchDispatchRetryResiliencePipeline) { }
         public static void OverrideImmediateDispatchRetryPolicy(this NServiceBus.IMessageHandlerContext context, Polly.AsyncPolicy immediateDispatchRetryPolicy) { }
+        public static void OverrideImmediateDispatchRetryResilienceStrategy(this NServiceBus.IMessageHandlerContext context, Polly.ResiliencePipeline immediateDispatchRetryResiliencePipeline) { }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -7,11 +7,11 @@ namespace NServiceBus
         [System.Obsolete("Favor using ResiliencePipeline via the DefaultBatchDispatchRetriesResiliencePipel" +
             "ine, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultBatchDispatchRetriesPolicy(Polly.AsyncPolicy batchDispatchRetryPolicy) { }
-        public void DefaultBatchDispatchRetriesResiliencePipeline(Polly.ResiliencePipeline batchDispatchResiliencePipeline) { }
+        public void DefaultBatchDispatchRetriesResilienceStrategy(Polly.ResiliencePipeline batchDispatchResiliencePipeline) { }
         [System.Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResilienceP" +
             "ipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultImmediateDispatchRetriesPolicy(Polly.AsyncPolicy immediateDispatchRetryPolicy) { }
-        public void DefaultImmediateDispatchRetriesResiliencePipeline(Polly.ResiliencePipeline immediateDispatchRetryResiliencePipeline) { }
+        public void DefaultImmediateDispatchRetriesResilienceStrategy(Polly.ResiliencePipeline immediateDispatchRetryResiliencePipeline) { }
     }
     public static class DispatchRetriesEndpointConfigurationExtensions
     {

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/mauroservienti/NServiceBus.Extensions.DispatchRetries")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NServiceBus.Extensions.DispatchRetries.AcceptanceTests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace NServiceBus
 {

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -4,12 +4,8 @@ namespace NServiceBus
 {
     public class DispatchRetriesConfiguration
     {
-        [System.Obsolete("Favor using ResiliencePipeline via the DefaultBatchDispatchRetriesResiliencePipel" +
-            "ine, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultBatchDispatchRetriesPolicy(Polly.AsyncPolicy batchDispatchRetryPolicy) { }
         public void DefaultBatchDispatchRetriesResilienceStrategy(Polly.ResiliencePipeline batchDispatchResiliencePipeline) { }
-        [System.Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResilienceP" +
-            "ipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultImmediateDispatchRetriesPolicy(Polly.AsyncPolicy immediateDispatchRetryPolicy) { }
         public void DefaultImmediateDispatchRetriesResilienceStrategy(Polly.ResiliencePipeline immediateDispatchRetryResiliencePipeline) { }
     }

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -4,14 +4,20 @@ namespace NServiceBus
 {
     public class DispatchRetriesConfiguration
     {
-        public DispatchRetriesConfiguration(NServiceBus.EndpointConfiguration configuration, Polly.AsyncPolicy defaultBatchAndImmediateDispatchRetriesPolicy) { }
+        [System.Obsolete("Favor using ResiliencePipeline via the DefaultBatchDispatchRetriesResiliencePipel" +
+            "ine, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultBatchDispatchRetriesPolicy(Polly.AsyncPolicy batchDispatchRetryPolicy) { }
+        public void DefaultBatchDispatchRetriesResiliencePipeline(Polly.ResiliencePipeline batchDispatchResiliencePipeline) { }
+        [System.Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResilienceP" +
+            "ipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultImmediateDispatchRetriesPolicy(Polly.AsyncPolicy immediateDispatchRetryPolicy) { }
+        public void DefaultImmediateDispatchRetriesResiliencePipeline(Polly.ResiliencePipeline immediateDispatchRetryResiliencePipeline) { }
     }
     public static class DispatchRetriesEndpointConfigurationExtensions
     {
         public static NServiceBus.DispatchRetriesConfiguration DispatchRetries(this NServiceBus.EndpointConfiguration configuration) { }
         public static NServiceBus.DispatchRetriesConfiguration DispatchRetries(this NServiceBus.EndpointConfiguration configuration, Polly.AsyncPolicy defaultBatchAndImmediateDispatchRetriesPolicy) { }
+        public static NServiceBus.DispatchRetriesConfiguration DispatchRetries(this NServiceBus.EndpointConfiguration configuration, Polly.ResiliencePipeline defaultBatchAndImmediateDispatchRetriesResiliencePipeline) { }
     }
     public static class MessageHandlerContextExtensions
     {

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -22,6 +22,7 @@ namespace NServiceBus
     public static class MessageHandlerContextExtensions
     {
         public static void OverrideBatchDispatchRetryPolicy(this NServiceBus.IMessageHandlerContext context, Polly.AsyncPolicy batchDispatchRetryPolicy) { }
+        public static void OverrideBatchDispatchRetryStrategy(this NServiceBus.IMessageHandlerContext context, Polly.ResiliencePipeline batchDispatchRetryResiliencePipeline) { }
         public static void OverrideImmediateDispatchRetryPolicy(this NServiceBus.IMessageHandlerContext context, Polly.AsyncPolicy immediateDispatchRetryPolicy) { }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/NServiceBus.Extensions.DispatchRetries.Tests.csproj
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/NServiceBus.Extensions.DispatchRetries.Tests.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NServiceBus" Version="9.2.2" />
     <PackageReference Include="ApprovalTests" Version="6.0.0" />
     <PackageReference Include="ApprovalUtilities" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />

--- a/src/NServiceBus.Extensions.DispatchRetries.Tests/NServiceBus.Extensions.DispatchRetries.Tests.csproj
+++ b/src/NServiceBus.Extensions.DispatchRetries.Tests/NServiceBus.Extensions.DispatchRetries.Tests.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.2.2" />
+    <PackageReference Include="Polly" Version="8.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Extensions.DispatchRetries\NServiceBus.Extensions.DispatchRetries.csproj" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
@@ -17,12 +17,14 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
         public override Task Invoke(IBatchDispatchContext context, Func<Task> next)
         {
+            //TODO: Add support for the resilience pipelines
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             if (overrides.BatchDispatchPolicyOverride != null)
             {
                 return overrides.BatchDispatchPolicyOverride.ExecuteAsync(next);
             }
 
+            //TODO: Add support for the resilience pipelines
             if (_defaultRetryPolicy!= null)
             {
                 return _defaultRetryPolicy.ExecuteAsync(next);

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
@@ -9,10 +9,17 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
     class BatchDispatchRetriesBehavior : Behavior<IBatchDispatchContext>
     {
         private readonly AsyncPolicy _defaultRetryPolicy;
+        private readonly ResiliencePipeline _defaultRetryResiliencePipeline;
 
         public BatchDispatchRetriesBehavior(IReadOnlySettings readOnlySettings)
         {
             readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryPolicy, out _defaultRetryPolicy);
+            readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryResiliencePipeline, out _defaultRetryResiliencePipeline);
+
+            if (_defaultRetryPolicy != null && _defaultRetryResiliencePipeline != null)
+            {
+                //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used    
+            }
         }
 
         public override Task Invoke(IBatchDispatchContext context, Func<Task> next)
@@ -24,7 +31,11 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
                 return overrides.BatchDispatchPolicyOverride.ExecuteAsync(next);
             }
 
-            //TODO: Add support for the resilience pipelines
+            if (_defaultRetryResiliencePipeline != null)
+            {
+                return _defaultRetryResiliencePipeline.ExecuteAsync(_=>new ValueTask(next()), context.CancellationToken).AsTask();
+            }
+            
             if (_defaultRetryPolicy!= null)
             {
                 return _defaultRetryPolicy.ExecuteAsync(next);

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
@@ -24,8 +24,12 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
         public override Task Invoke(IBatchDispatchContext context, Func<Task> next)
         {
-            //TODO: Add support for the resilience pipelines
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
+            if (overrides.BatchDispatchResiliencePipelineOverride != null)
+            {
+                return overrides.BatchDispatchResiliencePipelineOverride.ExecuteAsync(_=>new ValueTask(next()), context.CancellationToken).AsTask();
+            }
+            
             if (overrides.BatchDispatchPolicyOverride != null)
             {
                 return overrides.BatchDispatchPolicyOverride.ExecuteAsync(next);

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/BatchDispatchRetriesBehavior.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using NServiceBus.Logging;
 using NServiceBus.Pipeline;
 using NServiceBus.Settings;
 using Polly;
@@ -8,6 +9,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 {
     class BatchDispatchRetriesBehavior : Behavior<IBatchDispatchContext>
     {
+        static ILog logger = LogManager.GetLogger(typeof(BatchDispatchRetriesBehavior));
         private readonly AsyncPolicy _defaultRetryPolicy;
         private readonly ResiliencePipeline _defaultRetryResiliencePipeline;
 
@@ -18,7 +20,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
             if (_defaultRetryPolicy != null && _defaultRetryResiliencePipeline != null)
             {
-                //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used    
+                logger.Warn("Both a default batch dispatch retry policy and a batch dispatch retry resilience strategy are configured. Only the batch dispatch retry resilience strategy will be used.");
             }
         }
 

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesBehavior.cs
@@ -8,7 +8,6 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
     {
         public override Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
-            //TODO: Add support for the resilience pipelines
             context.Extensions.Set(Constants.IncomingMessage, true);
             context.Extensions.Set(Constants.Overrides, new DispatchRetriesOverrides());
 

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesBehavior.cs
@@ -8,6 +8,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
     {
         public override Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
+            //TODO: Add support for the resilience pipelines
             context.Extensions.Set(Constants.IncomingMessage, true);
             context.Extensions.Set(Constants.Overrides, new DispatchRetriesOverrides());
 

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesNoIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesNoIncomingMessageBehavior.cs
@@ -8,6 +8,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
     {
         public override Task Invoke(IRoutingContext context, Func<Task> next)
         {
+            //TODO: Add support for the resilience pipelines
             if (!context.Extensions.TryGet<bool>(Constants.IncomingMessage, out var isIncomingMessage))
             {
                 context.Extensions.Set(Constants.Overrides, new DispatchRetriesOverrides());

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesNoIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/DispatchRetriesOverridesNoIncomingMessageBehavior.cs
@@ -8,8 +8,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
     {
         public override Task Invoke(IRoutingContext context, Func<Task> next)
         {
-            //TODO: Add support for the resilience pipelines
-            if (!context.Extensions.TryGet<bool>(Constants.IncomingMessage, out var isIncomingMessage))
+            if (!context.Extensions.TryGet<bool>(Constants.IncomingMessage, out _))
             {
                 context.Extensions.Set(Constants.Overrides, new DispatchRetriesOverrides());
             }

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
@@ -12,19 +12,28 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
     class ImmediateDispatchRetriesBehavior : Behavior<IDispatchContext>
     {
         private readonly AsyncPolicy _defaultImmediateRetryPolicy;
+        private readonly ResiliencePipeline _defaultImmediateRetryResiliencePipeline;
+
         private readonly AsyncPolicy _defaultBatchRetryPolicy;
         private readonly ResiliencePipeline _defaultBatchRetryResiliencePipeline;
-        private readonly ResiliencePipeline _defaultImmediateRetryResiliencePipeline;
 
         public ImmediateDispatchRetriesBehavior(IReadOnlySettings readOnlySettings)
         {
             readOnlySettings.TryGet(Constants.DefaultImmediateDispatchRetryPolicy, out _defaultImmediateRetryPolicy);
-            readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryPolicy, out _defaultBatchRetryPolicy);
-            
-            readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryResiliencePipeline, out _defaultBatchRetryResiliencePipeline);
             readOnlySettings.TryGet(Constants.DefaultImmediateDispatchRetryResiliencePipeline, out _defaultImmediateRetryResiliencePipeline);
+
+            if (_defaultImmediateRetryPolicy != null && _defaultImmediateRetryResiliencePipeline != null)
+            {
+                //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used    
+            }
+
+            readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryPolicy, out _defaultBatchRetryPolicy);
+            readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryResiliencePipeline, out _defaultBatchRetryResiliencePipeline);
             
-            //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used
+            if (_defaultBatchRetryPolicy != null && _defaultBatchRetryResiliencePipeline != null)
+            {
+                //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used    
+            }
         }
 
         public override Task Invoke(IDispatchContext context, Func<Task> next)

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus.Pipeline;
 using NServiceBus.Settings;
@@ -34,6 +35,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
         Task HandleIsolatedConsistency(IDispatchContext context, Func<Task> next)
         {
+            //TODO: Add support for the resilience pipelines
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             if (overrides.ImmediateDispatchPolicyOverride != null)
             {
@@ -55,6 +57,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
         Task HandleDefaultConsistency(IDispatchContext context, Func<Task> next)
         {
+            //TODO: Add support for the resilience pipelines
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             if (overrides.BatchDispatchPolicyOverride != null)
             {

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
@@ -44,8 +44,12 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
         Task HandleIsolatedConsistency(IDispatchContext context, Func<Task> next)
         {
-            //TODO: Add support for the resilience pipelines
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
+            if (overrides.ImmediateDispatchResiliencePipelineOverride != null)
+            {
+                return overrides.ImmediateDispatchResiliencePipelineOverride.ExecuteAsync(_=> new ValueTask(next()), context.CancellationToken).AsTask();
+            }
+            
             if (overrides.ImmediateDispatchPolicyOverride != null)
             {
                 return overrides.ImmediateDispatchPolicyOverride.ExecuteAsync(next);
@@ -66,8 +70,12 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
         Task HandleDefaultConsistency(IDispatchContext context, Func<Task> next)
         {
-            //TODO: Add support for the resilience pipelines
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
+            if (overrides.BatchDispatchResiliencePipelineOverride != null)
+            {
+                return overrides.BatchDispatchResiliencePipelineOverride.ExecuteAsync(_=>new ValueTask(next()), context.CancellationToken).AsTask();
+            }
+            
             if (overrides.BatchDispatchPolicyOverride != null)
             {
                 return overrides.BatchDispatchPolicyOverride.ExecuteAsync(next);

--- a/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Behaviors/ImmediateDispatchRetriesBehavior.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NServiceBus.Logging;
 using NServiceBus.Pipeline;
 using NServiceBus.Settings;
 using NServiceBus.Transport;
@@ -11,6 +12,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 {
     class ImmediateDispatchRetriesBehavior : Behavior<IDispatchContext>
     {
+        static ILog logger = LogManager.GetLogger(typeof(ImmediateDispatchRetriesBehavior));
         private readonly AsyncPolicy _defaultImmediateRetryPolicy;
         private readonly ResiliencePipeline _defaultImmediateRetryResiliencePipeline;
 
@@ -24,7 +26,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
 
             if (_defaultImmediateRetryPolicy != null && _defaultImmediateRetryResiliencePipeline != null)
             {
-                //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used    
+                logger.Warn("Both a default immediate dispatch retry policy and an immediate dispatch retry resilience strategy are configured. Only the immediate dispatch retry resilience strategy will be used.");
             }
 
             readOnlySettings.TryGet(Constants.DefaultBatchDispatchRetryPolicy, out _defaultBatchRetryPolicy);
@@ -32,7 +34,7 @@ namespace NServiceBus.Extensions.DispatchRetries.Behaviors
             
             if (_defaultBatchRetryPolicy != null && _defaultBatchRetryResiliencePipeline != null)
             {
-                //TODO warn if both a Policy and a ResiliencePipeline are set for the same dispatch mode and inform that only the ResiliencePipeline will be used    
+                logger.Warn("Both a default batch dispatch retry policy and a batch dispatch retry resilience strategy are configured. Only the batch dispatch retry resilience strategy will be used.");
             }
         }
 

--- a/src/NServiceBus.Extensions.DispatchRetries/Constants.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/Constants.cs
@@ -1,10 +1,12 @@
 ﻿namespace NServiceBus.Extensions.DispatchRetries
 {
-    class Constants
+    static class Constants
     {
         public const string Overrides="nservicebus-extensions-dispatchretries-overrides";
         public const string DefaultBatchDispatchRetryPolicy = "nservicebus-extensions-dispatchretries-default-batch-dispatch-retry-policy";
+        public const string DefaultBatchDispatchRetryResiliencePipeline = "nservicebus-extensions-dispatchretries-default-batch-dispatch-retry-resilience-pipeline";
         public const string DefaultImmediateDispatchRetryPolicy = "nservicebus-extensions-dispatchretries-default-immediate-dispatch-retry-policy";
+        public const string DefaultImmediateDispatchRetryResiliencePipeline = "nservicebus-extensions-dispatchretries-default-immediate-dispatch-retry-resilience-pipeline";
         public const string IncomingMessage = "nservicebus-extensions-dispatchretries-incoming-message";
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
@@ -17,8 +17,8 @@ namespace NServiceBus
             configuration.EnableFeature<DispatchRetriesFeature>();
         }
 
-        public DispatchRetriesConfiguration(EndpointConfiguration configuration, AsyncPolicy defaultBatchAndImmediateDispatchRetriesPolicy)
-        : this(configuration)
+        internal DispatchRetriesConfiguration(EndpointConfiguration configuration, AsyncPolicy defaultBatchAndImmediateDispatchRetriesPolicy)
+            : this(configuration)
         {
             DefaultBatchDispatchRetriesPolicy(defaultBatchAndImmediateDispatchRetriesPolicy);
             DefaultImmediateDispatchRetriesPolicy(defaultBatchAndImmediateDispatchRetriesPolicy);

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
@@ -23,7 +23,15 @@ namespace NServiceBus
             DefaultBatchDispatchRetriesPolicy(defaultBatchAndImmediateDispatchRetriesPolicy);
             DefaultImmediateDispatchRetriesPolicy(defaultBatchAndImmediateDispatchRetriesPolicy);
         }
+        
+        internal DispatchRetriesConfiguration(EndpointConfiguration configuration, ResiliencePipeline defaultBatchAndImmediateDispatchRetriesResiliencePipeline)
+            : this(configuration)
+        {
+            DefaultBatchDispatchRetriesResiliencePipeline(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
+            DefaultImmediateDispatchRetriesResiliencePipeline(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
+        }
 
+        [Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultImmediateDispatchRetriesPolicy(AsyncPolicy immediateDispatchRetryPolicy)
         {
             if (immediateDispatchRetryPolicy == null)
@@ -33,7 +41,18 @@ namespace NServiceBus
 
             _configuration.GetSettings().Set(Constants.DefaultImmediateDispatchRetryPolicy, immediateDispatchRetryPolicy);
         }
+        
+        public void DefaultImmediateDispatchRetriesResiliencePipeline(ResiliencePipeline immediateDispatchRetryResiliencePipeline)
+        {
+            if (immediateDispatchRetryResiliencePipeline == null)
+            {
+                throw new ArgumentNullException(nameof(immediateDispatchRetryResiliencePipeline));
+            }
 
+            _configuration.GetSettings().Set(Constants.DefaultImmediateDispatchRetryResiliencePipeline, immediateDispatchRetryResiliencePipeline);
+        }
+
+        [Obsolete("Favor using ResiliencePipeline via the DefaultBatchDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultBatchDispatchRetriesPolicy(AsyncPolicy batchDispatchRetryPolicy)
         {
             if (batchDispatchRetryPolicy == null)
@@ -42,6 +61,16 @@ namespace NServiceBus
             }
 
             _configuration.GetSettings().Set(Constants.DefaultBatchDispatchRetryPolicy, batchDispatchRetryPolicy);
+        }
+        
+        public void DefaultBatchDispatchRetriesResiliencePipeline(ResiliencePipeline batchDispatchResiliencePipeline)
+        {
+            if (batchDispatchResiliencePipeline == null)
+            {
+                throw new ArgumentNullException(nameof(batchDispatchResiliencePipeline));
+            }
+
+            _configuration.GetSettings().Set(Constants.DefaultBatchDispatchRetryResiliencePipeline, batchDispatchResiliencePipeline);
         }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
@@ -34,20 +34,14 @@ namespace NServiceBus
         [Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultImmediateDispatchRetriesPolicy(AsyncPolicy immediateDispatchRetryPolicy)
         {
-            if (immediateDispatchRetryPolicy == null)
-            {
-                throw new ArgumentNullException(nameof(immediateDispatchRetryPolicy));
-            }
+            ArgumentNullException.ThrowIfNull(immediateDispatchRetryPolicy);
 
             _configuration.GetSettings().Set(Constants.DefaultImmediateDispatchRetryPolicy, immediateDispatchRetryPolicy);
         }
         
         public void DefaultImmediateDispatchRetriesResiliencePipeline(ResiliencePipeline immediateDispatchRetryResiliencePipeline)
         {
-            if (immediateDispatchRetryResiliencePipeline == null)
-            {
-                throw new ArgumentNullException(nameof(immediateDispatchRetryResiliencePipeline));
-            }
+            ArgumentNullException.ThrowIfNull(immediateDispatchRetryResiliencePipeline);
 
             _configuration.GetSettings().Set(Constants.DefaultImmediateDispatchRetryResiliencePipeline, immediateDispatchRetryResiliencePipeline);
         }
@@ -55,20 +49,14 @@ namespace NServiceBus
         [Obsolete("Favor using ResiliencePipeline via the DefaultBatchDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultBatchDispatchRetriesPolicy(AsyncPolicy batchDispatchRetryPolicy)
         {
-            if (batchDispatchRetryPolicy == null)
-            {
-                throw new ArgumentNullException(nameof(batchDispatchRetryPolicy));
-            }
+            ArgumentNullException.ThrowIfNull(batchDispatchRetryPolicy);
 
             _configuration.GetSettings().Set(Constants.DefaultBatchDispatchRetryPolicy, batchDispatchRetryPolicy);
         }
         
         public void DefaultBatchDispatchRetriesResiliencePipeline(ResiliencePipeline batchDispatchResiliencePipeline)
         {
-            if (batchDispatchResiliencePipeline == null)
-            {
-                throw new ArgumentNullException(nameof(batchDispatchResiliencePipeline));
-            }
+            ArgumentNullException.ThrowIfNull(batchDispatchResiliencePipeline);
 
             _configuration.GetSettings().Set(Constants.DefaultBatchDispatchRetryResiliencePipeline, batchDispatchResiliencePipeline);
         }

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
@@ -31,7 +31,6 @@ namespace NServiceBus
             DefaultImmediateDispatchRetriesResilienceStrategy(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
         }
 
-        [Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultImmediateDispatchRetriesPolicy(AsyncPolicy immediateDispatchRetryPolicy)
         {
             ArgumentNullException.ThrowIfNull(immediateDispatchRetryPolicy);
@@ -46,7 +45,6 @@ namespace NServiceBus
             _configuration.GetSettings().Set(Constants.DefaultImmediateDispatchRetryResiliencePipeline, immediateDispatchRetryResiliencePipeline);
         }
 
-        [Obsolete("Favor using ResiliencePipeline via the DefaultBatchDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
         public void DefaultBatchDispatchRetriesPolicy(AsyncPolicy batchDispatchRetryPolicy)
         {
             ArgumentNullException.ThrowIfNull(batchDispatchRetryPolicy);

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesConfiguration.cs
@@ -27,8 +27,8 @@ namespace NServiceBus
         internal DispatchRetriesConfiguration(EndpointConfiguration configuration, ResiliencePipeline defaultBatchAndImmediateDispatchRetriesResiliencePipeline)
             : this(configuration)
         {
-            DefaultBatchDispatchRetriesResiliencePipeline(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
-            DefaultImmediateDispatchRetriesResiliencePipeline(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
+            DefaultBatchDispatchRetriesResilienceStrategy(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
+            DefaultImmediateDispatchRetriesResilienceStrategy(defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
         }
 
         [Obsolete("Favor using ResiliencePipeline via the DefaultImmediateDispatchRetriesResiliencePipeline, this method will be treated as an error starting V4 and removed in V5.")]
@@ -39,7 +39,7 @@ namespace NServiceBus
             _configuration.GetSettings().Set(Constants.DefaultImmediateDispatchRetryPolicy, immediateDispatchRetryPolicy);
         }
         
-        public void DefaultImmediateDispatchRetriesResiliencePipeline(ResiliencePipeline immediateDispatchRetryResiliencePipeline)
+        public void DefaultImmediateDispatchRetriesResilienceStrategy(ResiliencePipeline immediateDispatchRetryResiliencePipeline)
         {
             ArgumentNullException.ThrowIfNull(immediateDispatchRetryResiliencePipeline);
 
@@ -54,7 +54,7 @@ namespace NServiceBus
             _configuration.GetSettings().Set(Constants.DefaultBatchDispatchRetryPolicy, batchDispatchRetryPolicy);
         }
         
-        public void DefaultBatchDispatchRetriesResiliencePipeline(ResiliencePipeline batchDispatchResiliencePipeline)
+        public void DefaultBatchDispatchRetriesResilienceStrategy(ResiliencePipeline batchDispatchResiliencePipeline)
         {
             ArgumentNullException.ThrowIfNull(batchDispatchResiliencePipeline);
 

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesEndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesEndpointConfigurationExtensions.cs
@@ -13,5 +13,10 @@ namespace NServiceBus
         {
             return new DispatchRetriesConfiguration(configuration, defaultBatchAndImmediateDispatchRetriesPolicy);
         }
+        
+        public static DispatchRetriesConfiguration DispatchRetries(this EndpointConfiguration configuration, ResiliencePipeline defaultBatchAndImmediateDispatchRetriesResiliencePipeline)
+        {
+            return new DispatchRetriesConfiguration(configuration, defaultBatchAndImmediateDispatchRetriesResiliencePipeline);
+        }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesOverrides.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesOverrides.cs
@@ -1,12 +1,62 @@
-﻿using Polly;
+﻿using NServiceBus.Logging;
+using Polly;
 
 namespace NServiceBus.Extensions.DispatchRetries
 {
     class DispatchRetriesOverrides
     {
-        public AsyncPolicy BatchDispatchPolicyOverride { get; set; }
-        public AsyncPolicy ImmediateDispatchPolicyOverride { get; set; }
-        public ResiliencePipeline BatchDispatchResiliencePipelineOverride { get; set; }
-        public ResiliencePipeline ImmediateDispatchResiliencePipelineOverride { get; set; }
+        static ILog logger = LogManager.GetLogger(typeof(DispatchRetriesOverrides));
+        private AsyncPolicy _batchDispatchPolicyOverride;
+        private AsyncPolicy _immediateDispatchPolicyOverride;
+        private ResiliencePipeline _batchDispatchResiliencePipelineOverride;
+        private ResiliencePipeline _immediateDispatchResiliencePipelineOverride;
+
+        public AsyncPolicy BatchDispatchPolicyOverride
+        {
+            get => _batchDispatchPolicyOverride;
+            set
+            {
+                _batchDispatchPolicyOverride = value;
+                LogWarningIfDuplicateBatchDispatchUsage();
+            }
+        }
+        
+        public ResiliencePipeline BatchDispatchResiliencePipelineOverride
+        {
+            get => _batchDispatchResiliencePipelineOverride;
+            set
+            {
+                _batchDispatchResiliencePipelineOverride = value;
+                LogWarningIfDuplicateBatchDispatchUsage();
+            }
+        }
+        
+        void LogWarningIfDuplicateBatchDispatchUsage()
+        {
+            if (_batchDispatchPolicyOverride != null && _batchDispatchResiliencePipelineOverride != null)
+            {
+                logger.Warn("Overrides for the batch dispatch retry policy and batch dispatch retry resilience strategy are configured. Only the batch dispatch retry resilience strategy override will be used.");
+            }
+        }
+
+        public AsyncPolicy ImmediateDispatchPolicyOverride
+        {
+            get => _immediateDispatchPolicyOverride;
+            set => _immediateDispatchPolicyOverride = value;
+        }
+
+        public ResiliencePipeline ImmediateDispatchResiliencePipelineOverride
+        {
+            get => _immediateDispatchResiliencePipelineOverride;
+            set => _immediateDispatchResiliencePipelineOverride = value;
+        }
+        
+        void LogWarningIfDuplicateImmediateDispatchUsage()
+        {
+            if (_immediateDispatchPolicyOverride != null && _immediateDispatchResiliencePipelineOverride != null)
+            {
+                logger.Warn("Overrides for the immediate dispatch retry policy and immediate dispatch retry resilience strategy are configured. Only the immediate dispatch retry resilience strategy override will be used.");
+            }
+        }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesOverrides.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/DispatchRetriesOverrides.cs
@@ -6,5 +6,7 @@ namespace NServiceBus.Extensions.DispatchRetries
     {
         public AsyncPolicy BatchDispatchPolicyOverride { get; set; }
         public AsyncPolicy ImmediateDispatchPolicyOverride { get; set; }
+        public ResiliencePipeline BatchDispatchResiliencePipelineOverride { get; set; }
+        public ResiliencePipeline ImmediateDispatchResiliencePipelineOverride { get; set; }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries/InternalsVisibleTo.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("NServiceBus.Extensions.DispatchRetries.AcceptanceTests")]

--- a/src/NServiceBus.Extensions.DispatchRetries/MessageHandlerContextExtensions.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/MessageHandlerContextExtensions.cs
@@ -27,5 +27,16 @@ namespace NServiceBus
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             overrides.BatchDispatchPolicyOverride = batchDispatchRetryPolicy;
         }
+        
+        public static void OverrideBatchDispatchRetryStrategy(this IMessageHandlerContext context, ResiliencePipeline batchDispatchRetryResiliencePipeline)
+        {
+            if (batchDispatchRetryResiliencePipeline == null)
+            {
+                throw new ArgumentNullException(nameof(batchDispatchRetryResiliencePipeline));
+            }
+
+            var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
+            overrides.BatchDispatchResiliencePipelineOverride = batchDispatchRetryResiliencePipeline;
+        }
     }
 }

--- a/src/NServiceBus.Extensions.DispatchRetries/MessageHandlerContextExtensions.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/MessageHandlerContextExtensions.cs
@@ -13,6 +13,14 @@ namespace NServiceBus
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             overrides.ImmediateDispatchPolicyOverride = immediateDispatchRetryPolicy;
         }
+        
+        public static void OverrideImmediateDispatchRetryResilienceStrategy(this IMessageHandlerContext context, ResiliencePipeline immediateDispatchRetryResiliencePipeline)
+        {
+            ArgumentNullException.ThrowIfNull(immediateDispatchRetryResiliencePipeline);
+
+            var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
+            overrides.ImmediateDispatchResiliencePipelineOverride = immediateDispatchRetryResiliencePipeline;
+        }
 
         public static void OverrideBatchDispatchRetryPolicy(this IMessageHandlerContext context, AsyncPolicy batchDispatchRetryPolicy)
         {
@@ -22,7 +30,7 @@ namespace NServiceBus
             overrides.BatchDispatchPolicyOverride = batchDispatchRetryPolicy;
         }
         
-        public static void OverrideBatchDispatchRetryStrategy(this IMessageHandlerContext context, ResiliencePipeline batchDispatchRetryResiliencePipeline)
+        public static void OverrideBatchDispatchRetryResilienceStrategy(this IMessageHandlerContext context, ResiliencePipeline batchDispatchRetryResiliencePipeline)
         {
             ArgumentNullException.ThrowIfNull(batchDispatchRetryResiliencePipeline);
 

--- a/src/NServiceBus.Extensions.DispatchRetries/MessageHandlerContextExtensions.cs
+++ b/src/NServiceBus.Extensions.DispatchRetries/MessageHandlerContextExtensions.cs
@@ -8,10 +8,7 @@ namespace NServiceBus
     {
         public static void OverrideImmediateDispatchRetryPolicy(this IMessageHandlerContext context, AsyncPolicy immediateDispatchRetryPolicy)
         {
-            if (immediateDispatchRetryPolicy == null)
-            {
-                throw new ArgumentNullException(nameof(immediateDispatchRetryPolicy));
-            }
+            ArgumentNullException.ThrowIfNull(immediateDispatchRetryPolicy);
 
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             overrides.ImmediateDispatchPolicyOverride = immediateDispatchRetryPolicy;
@@ -19,10 +16,7 @@ namespace NServiceBus
 
         public static void OverrideBatchDispatchRetryPolicy(this IMessageHandlerContext context, AsyncPolicy batchDispatchRetryPolicy)
         {
-            if (batchDispatchRetryPolicy == null)
-            {
-                throw new ArgumentNullException(nameof(batchDispatchRetryPolicy));
-            }
+            ArgumentNullException.ThrowIfNull(batchDispatchRetryPolicy);
 
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             overrides.BatchDispatchPolicyOverride = batchDispatchRetryPolicy;
@@ -30,10 +24,7 @@ namespace NServiceBus
         
         public static void OverrideBatchDispatchRetryStrategy(this IMessageHandlerContext context, ResiliencePipeline batchDispatchRetryResiliencePipeline)
         {
-            if (batchDispatchRetryResiliencePipeline == null)
-            {
-                throw new ArgumentNullException(nameof(batchDispatchRetryResiliencePipeline));
-            }
+            ArgumentNullException.ThrowIfNull(batchDispatchRetryResiliencePipeline);
 
             var overrides = context.Extensions.Get<DispatchRetriesOverrides>(Constants.Overrides);
             overrides.BatchDispatchResiliencePipelineOverride = batchDispatchRetryResiliencePipeline;


### PR DESCRIPTION
- [x] Add support for Polly ResiliencePipelines side-by-side to Policies
- [x] Tests
- [x] Add tests to validate that when both a policy and a resilience strategy are applied, the resilience strategy wins
- [x] Documentation
- ~~[ ] Raise follow-up issues~~
- [x] Polly has not applied any `Obsolete` to the policies. Shall it be removed from here, too?
- [x] Rename the public `*ResiliencePipeline` members to `*Strategy`